### PR TITLE
Fixed problem with path separators on windows.

### DIFF
--- a/tasks/webdav_sync.js
+++ b/tasks/webdav_sync.js
@@ -157,7 +157,7 @@ module.exports = function(grunt) {
         files.forEach(function(file) {
             var key = getUploadKey(file, localPath);
             var parent = getParentUploadKey(key);
-            var remoteURL = url.resolve(remote_path, path.relative(localPath, file));
+            var remoteURL = url.resolve(remote_path, path.relative(localPath, file).replace(/\\/g, '/'));
             var isDir = grunt.file.isDir(file);
 
             if(isDir) {


### PR DESCRIPTION
Hey,

Some WebDAV servers don't seem to like backward slashes "\" in their paths, so I added some code to replace all "\" with "/".

Enjoy!
