### PR TITLE
Fix issue with binary encoded files (images)

### DIFF
--- a/tasks/webdav_sync.js
+++ b/tasks/webdav_sync.js
@@ -195,9 +195,9 @@ module.exports = function(grunt) {
                     
                 });
             } else {
-				var options = {};
+                var options = {};
                 //if it is a binary image file, skip encoding
-                if(file.match(/\.(jpg|jpeg|png|gif|ico|psd)$/)){
+                if(file.match(/\.(jpg|jpeg|png|gif|ico|psd|eot|woff|ttf|otf|jar|zip|swf|pdf)$/)){
                     options.encoding = null;
                 }
                 var buffer = grunt.file.read(file, options);


### PR DESCRIPTION
grunt.file.read tries to encode binary files to a string, this adds detection for some common binary image formats and skips the encoding for those files
